### PR TITLE
Clarify that the datasets are also BSD licensed

### DIFF
--- a/docs/data.md
+++ b/docs/data.md
@@ -32,3 +32,7 @@ test in the cloud to avoid having to deal with excessive render times or local d
 - [**Rendered Single Frame**](https://facebook360-dep-downloads.s3-us-west-2.amazonaws.com/room_chat/1_frame_unpacked_rendered.zip)
 - [**Frame Sequence**](https://facebook360-dep-downloads.s3-us-west-2.amazonaws.com/room_chat/50_frames_unpacked.zip)
 - [**Rendered Frame Sequence**](https://facebook360-dep-downloads.s3-us-west-2.amazonaws.com/room_chat/50_frames_unpacked_rendered.zip)
+
+### License
+
+These facebook360_dep datasets are BSD licensed, as found in the [LICENSE](/LICENSE) file.


### PR DESCRIPTION
## Summary

It was not clear to me how the provided data sets where licensed. I have opened issue #24 for that, and @aparrapo has clarified in a comment on that issue that the datasets also have BSD license. This pull requests adds the clarification.

## Changelog

[Docs][Improvement] - Clarify datasets license

## Test Plan

There is no code change. Please check the added text for correctness.
